### PR TITLE
preallocate sID cell

### DIFF
--- a/solver/system_solve_helper_load_point_matches.m
+++ b/solver/system_solve_helper_load_point_matches.m
@@ -56,6 +56,9 @@ else
 end
 ismontage = [];
 count  = 1;
+if ~opts.outside_group
+    sID_all = cell(numel(zu)*(opts.nbrs+1) - opts.nbrs * (opts.nbrs)+1/2,2);
+end
 for ix = 1:numel(zu)   % loop over sections  -- can this be made parfor?
     %disp(['Setting up section: ' sID{ix}]);
     sID_all{count,1} = sID{ix};


### PR DESCRIPTION
Preallocates sID cell in cases where not using outside_group. This speeds it up significantly for large datasets. With opts.outside_group it's more complicated so not done yet.